### PR TITLE
KASM-3699 have a fallback mode for gpuinfo script to simply list the cards

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,10 +39,21 @@ async function installerBlobs() {
     gpuData.push(data);
   });
   gpuCmd.on('close', function(code) {
-    if (code == 0) {
-      gpuInfo = JSON.parse(gpuData.join(''));
-    } else {
+    try {
+      if (code == 0) {
+        gpuInfo = JSON.parse(gpuData.join(''));
+      } else {
+        gpuInfo = {};
+      }
+    } catch (err) {
+      // Manually backfill GPU info if available
       gpuInfo = {};
+      for (let i = 0; i < 10; i++) {
+        let num = i.toString();
+        if (fs.existsSync('/dev/dri/card' + num)) {
+          gpuInfo['/dev/dri/card' + num] = "Unknown GPU";
+        }
+      }
     }
   });
 }


### PR DESCRIPTION
Got a report and was able to confirm it on an AWS Focal instance. I only ever tested really with read hardware. 

I need to cut this into the head develop and stable release and rebuild downstream. 