### PR TITLE
fix old bug if no images are selected install and upgrade bombs out

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,11 @@ io.on('connection', async function (socket) {
 
     // Write finalized image data
     let yamlStr = yaml.dump(imagesI);
-    await fsw.writeFile('/kasm_release/conf/database/seed_data/default_images_' + arch + '.yaml', yamlStr);
+    if (yamlStr.startsWith("false")) {
+      installFlags = installFlags.filter(function(e) { return e !== '-W' });
+    } else {
+      await fsw.writeFile('/kasm_release/conf/database/seed_data/default_images_' + arch + '.yaml', yamlStr);
+    }
 
     // Copy over version
     await fsw.copyFile('/version.txt', '/opt/version.txt');
@@ -153,7 +157,12 @@ io.on('connection', async function (socket) {
 
     // Write finalized image data
     let yamlStr = yaml.dump(imagesI);
-    await fsw.writeFile('/kasm_release/conf/database/seed_data/default_images_' + arch + '.yaml', yamlStr);
+    if (yamlStr.startsWith("false")) {
+      upgradeFlags = upgradeFlags.filter(function(e) { return e !== '-K' });
+      upgradeFlags = upgradeFlags.filter(function(e) { return e !== '-U' });
+    } else {
+      await fsw.writeFile('/kasm_release/conf/database/seed_data/default_images_' + arch + '.yaml', yamlStr);
+    }
 
     // Copy over version
     await fsw.copyFile('/version.txt', '/opt/version.txt');


### PR DESCRIPTION
So the wizard does not need any new updates with 1.14. But during testing I discovered this bug which borks out the install or upgrade if they have no images selected. It is more prevalent for an upgrade as many users might not want to touch their images at all. 