### PR TITLE
prevent calling setGpu when the image selection is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,11 @@ io.on('connection', async function (socket) {
 
     // Write finalized image data
     let yamlStr = yaml.dump(imagesI);
-    await fsw.writeFile('/kasm_release/conf/database/seed_data/default_images_' + arch + '.yaml', yamlStr);
+    if (yamlStr.startsWith("false")) {
+      installFlags = installFlags.filter(function(e) { return e !== '-W' });
+    } else {
+      await fsw.writeFile('/kasm_release/conf/database/seed_data/default_images_' + arch + '.yaml', yamlStr);
+    }
 
     // Copy over version
     await fsw.copyFile('/version.txt', '/opt/version.txt');
@@ -153,7 +157,12 @@ io.on('connection', async function (socket) {
 
     // Write finalized image data
     let yamlStr = yaml.dump(imagesI);
-    await fsw.writeFile('/kasm_release/conf/database/seed_data/default_images_' + arch + '.yaml', yamlStr);
+    if (yamlStr.startsWith("false")) {
+      upgradeFlags = upgradeFlags.filter(function(e) { return e !== '-K' });
+      upgradeFlags = upgradeFlags.filter(function(e) { return e !== '-U' });
+    } else {
+      await fsw.writeFile('/kasm_release/conf/database/seed_data/default_images_' + arch + '.yaml', yamlStr);
+    }
 
     // Copy over version
     await fsw.copyFile('/version.txt', '/opt/version.txt');

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ io.on('connection', async function (socket) {
     installSettings = data[0];
     let imagesI = data[1];
     let imagesD = images;
-    installFlags = ['/kasm_release/install.sh', '-B' ,'-H', '-e', '-L', port, '-P', installSettings.adminPass, '-U', installSettings.userPass];
+    installFlags = ['/kasm_release/install.sh', '-A', '-B' ,'-H', '-e', '-L', port, '-P', installSettings.adminPass, '-U', installSettings.userPass];
     if (installSettings.useRolling == true) {
       installFlags.push('-O');
     }

--- a/index.js
+++ b/index.js
@@ -39,10 +39,21 @@ async function installerBlobs() {
     gpuData.push(data);
   });
   gpuCmd.on('close', function(code) {
-    if (code == 0) {
-      gpuInfo = JSON.parse(gpuData.join(''));
-    } else {
+    try {
+      if (code == 0) {
+        gpuInfo = JSON.parse(gpuData.join(''));
+      } else {
+        gpuInfo = {};
+      }
+    } catch (err) {
+      // Manually backfill GPU info if available
       gpuInfo = {};
+      for (let i = 0; i < 10; i++) {
+        let num = i.toString();
+        if (fs.existsSync('/dev/dri/card' + num)) {
+          gpuInfo['/dev/dri/card' + num] = "Unknown GPU";
+        }
+      }
     }
   });
 }

--- a/index.js
+++ b/index.js
@@ -25,6 +25,8 @@ var EULA;
 var images;
 var currentVersion;
 var gpuInfo;
+var installSettings = {};
+var upgradeSettings = {};
 // Grab installer variables
 async function installerBlobs() {
   EULA = await fsw.readFile('/kasm_release/licenses/LICENSE.txt', 'utf8');

--- a/index.js
+++ b/index.js
@@ -76,10 +76,11 @@ io.on('connection', async function (socket) {
       let card = gpu.slice(-1);
       let render = (Number(card) + 128).toString();
       // Handle NVIDIA Gpus
+      var baseRun;
       if (gpuName.indexOf('NVIDIA') !== -1) {
-        let baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"],"device_requests":[{"driver": "","count": -1,"device_ids": null,"capabilities":[["gpu"]],"options":{}}]}');
+        baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"],"device_requests":[{"driver": "","count": -1,"device_ids": null,"capabilities":[["gpu"]],"options":{}}]}');
       } else {
-        let baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"]}');
+        baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"]}');
       }
       let baseExec = JSON.parse('{"first_launch":{"user":"root","cmd": "bash -c \'chown -R kasm-user:kasm-user /dev/dri/*\'"}}');
       for await (let image of Object.keys(images.images)) {

--- a/index.js
+++ b/index.js
@@ -71,9 +71,16 @@ io.on('connection', async function (socket) {
       }
     }
     if (installSettings.forceGpu !== 'disabled') {
-      let card = installSettings.forceGpu.slice(-1);
+      let gpu = installSettings.forceGpu.split('|')[0];
+      let gpuName = installSettings.forceGpu.split('|')[1];
+      let card = gpu.slice(-1);
       let render = (Number(card) + 128).toString();
-      let baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"]}');
+      // Handle NVIDIA Gpus
+      if (gpuName.indexOf('NVIDIA') !== -1) {
+        let baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"],"device_requests":[{"driver": "","count": -1,"device_ids": null,"capabilities":[["gpu"]],"options":{}}]}');
+      } else {
+        let baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"]}');
+      }
       let baseExec = JSON.parse('{"first_launch":{"user":"root","cmd": "bash -c \'chown -R kasm-user:kasm-user /dev/dri/*\'"}}');
       for await (let image of Object.keys(images.images)) {
         if (imagesD.images[image]['run_config']) {

--- a/index.js
+++ b/index.js
@@ -23,13 +23,62 @@ var port = process.env.KASM_PORT || '443';
 const { spawn } = require('node:child_process');
 var EULA;
 var images;
+var currentVersion;
+var gpuInfo;
 // Grab installer variables
 async function installerBlobs() {
   EULA = await fsw.readFile('/kasm_release/licenses/LICENSE.txt', 'utf8');
   let imagesText = await fsw.readFile('/wizard/default_images_' + arch + '.yaml', 'utf8');
   images = yaml.load(imagesText);
+  currentVersion = fs.readFileSync('/version.txt', 'utf8').replace(/(\r\n|\n|\r)/gm,'');
+  let gpuData = [];
+  let gpuCmd = spawn('/gpuinfo.sh');
+  gpuCmd.stdout.on('data', function(data) {
+    gpuData.push(data);
+  });
+  gpuCmd.on('close', function(code) {
+    if (code == 0) {
+      gpuInfo = JSON.parse(gpuData.join(''));
+    } else {
+      gpuInfo = {};
+    }
+  });
 }
 installerBlobs();
+
+// GPU image yaml merging
+async function setGpu(imagesD) {
+  if (upgradeSettings['forceGpu'] !== undefined) {
+    installSettings = upgradeSettings;
+  }
+  let gpu = installSettings.forceGpu.split('|')[0];
+  let gpuName = installSettings.forceGpu.split('|')[1];
+  let card = gpu.slice(-1);
+  let render = (Number(card) + 128).toString();
+  // Handle NVIDIA Gpus
+  var baseRun;
+  if (gpuName.indexOf('NVIDIA') !== -1) {
+    baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"],"device_requests":[{"driver": "","count": -1,"device_ids": null,"capabilities":[["gpu"]],"options":{}}]}');
+  } else {
+    baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"]}');
+  }
+  let baseExec = JSON.parse('{"first_launch":{"user":"root","cmd": "bash -c \'chown -R kasm-user:kasm-user /dev/dri/*\'"}}');
+  for await (let image of Object.keys(images.images)) {
+    if (imagesD.images[image]['run_config']) {
+      finalRun = _.merge(JSON.parse(imagesD.images[image]['run_config']), baseRun)
+    } else {
+      finalRun = baseRun;
+    }
+    if (imagesD.images[image]['exec_config']) {
+      finalExec = _.merge(JSON.parse(imagesD.images[image]['exec_config']), baseExec)
+    } else {
+      finalExec = baseExec;
+    }
+    imagesD.images[image]['run_config'] = JSON.stringify(finalRun);
+    imagesD.images[image]['exec_config'] = JSON.stringify(finalExec);
+  }
+  return imagesD;
+}
 
 //// Http server ////
 baserouter.use('/public', express.static(__dirname + '/public'));
@@ -47,6 +96,7 @@ io = socketIO(https, {path: baseUrl + 'socket.io'});
 io.on('connection', async function (socket) {
   // Run bash install with our custom flags
   async function install(data) {
+    // Determine install settings
     installSettings = data[0];
     let imagesI = data[1];
     let imagesD = images;
@@ -60,6 +110,7 @@ io.on('connection', async function (socket) {
     if ((imagesI.hasOwnProperty('images')) && (Object.keys(imagesI.images).length < 10)) {
       installFlags.push('-b');
     }
+
     // Flag the images properly based on selection
     for await (let image of Object.keys(images.images)) {
       if ((imagesI.hasOwnProperty('images')) && (imagesI.images.hasOwnProperty(image))) {
@@ -70,36 +121,20 @@ io.on('connection', async function (socket) {
         imagesD.images[image].hidden = true;
       }
     }
+
+    // GPU yaml merge
     if (installSettings.forceGpu !== 'disabled') {
-      let gpu = installSettings.forceGpu.split('|')[0];
-      let gpuName = installSettings.forceGpu.split('|')[1];
-      let card = gpu.slice(-1);
-      let render = (Number(card) + 128).toString();
-      // Handle NVIDIA Gpus
-      var baseRun;
-      if (gpuName.indexOf('NVIDIA') !== -1) {
-        baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"],"device_requests":[{"driver": "","count": -1,"device_ids": null,"capabilities":[["gpu"]],"options":{}}]}');
-      } else {
-        baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"]}');
-      }
-      let baseExec = JSON.parse('{"first_launch":{"user":"root","cmd": "bash -c \'chown -R kasm-user:kasm-user /dev/dri/*\'"}}');
-      for await (let image of Object.keys(images.images)) {
-        if (imagesD.images[image]['run_config']) {
-          finalRun = _.merge(JSON.parse(imagesD.images[image]['run_config']), baseRun)
-        } else {
-          finalRun = baseRun;
-        }
-        if (imagesD.images[image]['exec_config']) {
-          finalExec = _.merge(JSON.parse(imagesD.images[image]['exec_config']), baseExec)
-        } else {
-          finalExec = baseExec;
-        }
-        imagesD.images[image]['run_config'] = JSON.stringify(finalRun);
-        imagesD.images[image]['exec_config'] = JSON.stringify(finalExec);
-      }
+      imagesD = await setGpu(imagesD);
     }
+
+    // Write finalized image data
     let yamlStr = yaml.dump(imagesD);
     await fsw.writeFile('/kasm_release/conf/database/seed_data/default_images_' + arch + '.yaml', yamlStr);
+
+    // Copy over version
+    await fsw.copyFile('/version.txt', '/opt/version.txt');
+
+    // Run install
     let cmd = pty.spawn('/bin/bash', installFlags);
     cmd.on('data', function(data) {
       socket.emit('term', data);
@@ -110,30 +145,78 @@ io.on('connection', async function (socket) {
       }
     });
   }
+
+  // Run bash upgrade with our custom flags
+  async function upgrade(data) {
+    // Determine upgrade settings
+    upgradeSettings = data[0];
+    let imagesI = data[1];
+    let imagesD = images;
+    upgradeFlags = ['/kasm_release/upgrade.sh', '-A', '-L', port];
+    if (upgradeSettings.keepOldImages == true) {
+      upgradeFlags.push('-K');
+    } else {
+      upgradeFlags.push('-U');
+    }
+
+    // Flag the images properly based on selection
+    for await (let image of Object.keys(images.images)) {
+      if ((imagesI.hasOwnProperty('images')) && (imagesI.images.hasOwnProperty(image))) {
+        imagesD.images[image].enabled = true;
+        imagesD.images[image].hidden = false;
+      } else {
+        imagesD.images[image].enabled = false;
+        imagesD.images[image].hidden = true;
+      }
+    }
+
+    // GPU yaml merge
+    if (upgradeSettings.forceGpu !== 'disabled') {
+      imagesD = await setGpu(imagesD);
+    }
+
+    // Write finalized image data
+    let yamlStr = yaml.dump(imagesD);
+    await fsw.writeFile('/kasm_release/conf/database/seed_data/default_images_' + arch + '.yaml', yamlStr);
+
+    // Copy over version
+    await fsw.copyFile('/version.txt', '/opt/version.txt');
+
+    // Run upgrade
+    let cmd = pty.spawn('/bin/bash', upgradeFlags);
+    cmd.on('data', function(data) {
+      socket.emit('term', data);
+    });
+    cmd.on('exit', function(code, signal) {
+      if (code == 0) {
+        socket.emit('done', port);
+      }
+    });
+  }
+
   // Render landing page depending on installed status
   async function renderLanding() {
     let containers = await docker.listContainers();
+    // This is a running system
     if (containers.length !== 0) {
       let dashinfo = {};
+      // Get version information
+      if (fs.existsSync('/opt/version.txt')) {
+        dashinfo['localVersion'] = fs.readFileSync('/opt/version.txt', 'utf8').replace(/(\r\n|\n|\r)/gm,''); 
+      } else {
+        dashinfo['localVersion'] = 'Unknown';
+      }
+      dashinfo['currentVersion'] = currentVersion;
+      dashinfo['gpuInfo'] = gpuInfo;
       dashinfo['containers'] = containers;
       dashinfo['cpu'] = await si.cpu();
       dashinfo['mem'] = await si.mem();
       dashinfo['cpuPercent'] = await si.currentLoad();
       dashinfo['port'] = port;
-      socket.emit('renderdash', dashinfo);
+      socket.emit('renderdash', [dashinfo, images]);
+    // Render installer
     } else {
-      let gpuData = [];
-      let gpuCmd = spawn('/gpuinfo.sh');
-      gpuCmd.stdout.on('data', function(data) {
-        gpuData.push(data);
-      });
-      gpuCmd.on('close', function(code) {
-        if (code == 0) {
-          socket.emit('renderinstall', [EULA, images, JSON.parse(gpuData.join(''))]);
-        } else {
-          socket.emit('renderinstall', [EULA, images, {}]);
-        }
-      });
+      socket.emit('renderinstall', [EULA, images, gpuInfo]);
     }
   }
   // Disable wizard
@@ -145,5 +228,6 @@ io.on('connection', async function (socket) {
   //// Incoming requests ////
   socket.on('renderlanding', renderLanding);
   socket.on('install', install);
+  socket.on('upgrade', upgrade);
   socket.on('nowizard', noWizard);
 });

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ io.on('connection', async function (socket) {
     }
 
     // GPU yaml merge
-    if (installSettings.forceGpu !== 'disabled') {
+    if (installSettings.forceGpu !== 'disabled' && imagesI.images) {
       imagesI = await setGpu(imagesI);
     }
 
@@ -151,7 +151,7 @@ io.on('connection', async function (socket) {
     }
 
     // GPU yaml merge
-    if (upgradeSettings.forceGpu !== 'disabled') {
+    if (upgradeSettings.forceGpu !== 'disabled'  && imagesI.images) {
       imagesI = await setGpu(imagesI);
     }
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ async function setGpu(imagesI) {
   // Handle NVIDIA Gpus
   var baseRun;
   if (gpuName.indexOf('NVIDIA') !== -1) {
-    baseRun = JSON.parse('{"environment":{"KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"],"device_requests":[{"driver": "","count": -1,"device_ids": null,"capabilities":[["gpu"]],"options":{}}]}');
+    baseRun = JSON.parse('{"runtime":"nvidia","environment":{"NVIDIA_DRIVER_CAPABILITIES":"all","KASM_EGL_CARD":"/dev/dri/card' + card + '","KASM_RENDERD":"/dev/dri/renderD' + render + '"},"device_requests":[{"driver": "","count": -1,"device_ids": null,"capabilities":[["gpu"]],"options":{}}]}');
   } else {
     baseRun = JSON.parse('{"environment":{"DRINODE":"/dev/dri/renderD' + render + '", "HW3D": true},"devices":["/dev/dri/card' + card + ':/dev/dri/card' + card + ':rwm","/dev/dri/renderD' + render + ':/dev/dri/renderD' + render + ':rwm"]}');
   }

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ io.on('connection', async function (socket) {
     // Determine install settings
     installSettings = data[0];
     var imagesI = data[1];
-    installFlags = ['/kasm_release/install.sh', '-W', '-A', '-B' ,'-H', '-e', '-L', port, '-P', installSettings.adminPass, '-U', installSettings.userPass];
+    installFlags = ['/kasm_release/install.sh', '-W', '-B' ,'-H', '-e', '-L', port, '-P', installSettings.adminPass, '-U', installSettings.userPass];
     if ((imagesI.hasOwnProperty('images')) && (imagesI.images.length < 10)) {
       installFlags.push('-b');
     }
@@ -143,7 +143,7 @@ io.on('connection', async function (socket) {
     // Determine upgrade settings
     upgradeSettings = data[0];
     var imagesI = data[1];
-    upgradeFlags = ['/kasm_release/upgrade.sh', '-A', '-L', port];
+    upgradeFlags = ['/kasm_release/upgrade.sh', '-L', port];
     if (upgradeSettings.keepOldImages == true) {
       upgradeFlags.push('-K');
     } else {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dockerode": "^3.3.2",
     "express": "^4.18.1",
     "js-yaml": "^4.1.0",
+    "lodash": "^4.17.21",
     "node-pty": "^0.10.1",
     "socket.io": "^4.5.1",
     "systeminformation": "^5.11.16"

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -199,7 +199,7 @@ async function pickSettings() {
   ]);
   let gpuOptions = [$('<option>', {value: 'disabled'}).text('Disabled')];
   for await (let card of Object.keys(gpus)) {
-    gpuOptions.push($('<option>', {value: card}).text(card + ' - ' + gpus[card]));
+    gpuOptions.push($('<option>', {value: card + '|' + gpus[card]}).text(card + ' - ' + gpus[card]));
   }
   let forceGpu = $('<div>', {class: 'form-group'}).append([
     $('<label>', {for: 'forceGpu'}).text('Use GPU on all images: '),

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,6 +1,7 @@
 // Variables
 var EULA;
 var images;
+var gpus;
 var term;
 var installImages = [];
 var installSettings = {};
@@ -73,6 +74,7 @@ function renderInstall(data) {
   titleChange('EULA');
   EULA = data[0];
   images = data[1];
+  gpus = data[2];
   let EULADiv = $('<div>', {id: 'EULA'}).text(EULA);
   $('#container').append(EULADiv);
   let EULAButton = $('<button>', {id: 'EULAButton', onclick: 'pickSettings()', class: 'btn btn-default btn-ghost'}).text('Accept and continue');
@@ -195,6 +197,14 @@ async function pickSettings() {
     $('<label>', {for: 'noDownload'}).text('Skip Image Download: '),
     $('<input>', {name: 'noDownload', id: 'noDownload', type: 'checkbox'})
   ]);
+  let gpuOptions = [$('<option>', {value: 'disabled'}).text('Disabled')];
+  for await (let card of Object.keys(gpus)) {
+    gpuOptions.push($('<option>', {value: card}).text(card + ' - ' + gpus[card]));
+  }
+  let forceGpu = $('<div>', {class: 'form-group'}).append([
+    $('<label>', {for: 'forceGpu'}).text('Use GPU on all images: '),
+    $('<select>', {name: 'forceGpu', id: 'forceGpu',}).append(gpuOptions)
+  ]);
   let submit = $('<div>', {class: 'form-group'}).append([
     $('<input>', {name: 'submit', type: 'submit', value: 'Next', class: 'btn btn-default btn-ghost'})
   ]);
@@ -203,6 +213,7 @@ async function pickSettings() {
     userPass,
     useRolling,
     noDownload,
+    forceGpu,
     submit
   ]);
   form.append(fieldset);
@@ -214,6 +225,7 @@ async function pickSettings() {
     installSettings.userPass = $('#userPass').val();
     installSettings.useRolling = $('#useRolling').is(":checked");
     installSettings.noDownload = $('#noDownload').is(":checked");
+    installSettings.forceGpu = $('#forceGpu').val();
     pickImages();
   });
 }


### PR DESCRIPTION
Calling setGpu when user hasnt seleted any images causes the wizzard to crash with the following error:

```js
/wizard/index.js:79
  for (var i=0; i<imagesI.images.length; i++) {
                                 ^

TypeError: Cannot read properties of undefined (reading 'length')
    at setGpu (/wizard/index.js:79:34)
    at Socket.install (/wizard/index.js:115:23)
    at Socket.emit (node:events:517:28)
    at Socket.emitUntyped (/wizard/node_modules/socket.io/dist/typed-events.js:69:22)
    at /wizard/node_modules/socket.io/dist/socket.js:697:39
    at process.processTicksAndRejections (node:internal/process/task_queues:77:11)

Node.js v18.20.6
```

This occurs whenever user choses to use the GPU but skips selecting an image.

### The fix
- Prevented calling setGpu when there are no images selected